### PR TITLE
Ssl nginx

### DIFF
--- a/.htpasswd
+++ b/.htpasswd
@@ -1,1 +1,0 @@
-elasticsearch:$apr1$p9/CFER9$PKuf/qnRptyWog1lHdE0E/

--- a/create-keys.sh
+++ b/create-keys.sh
@@ -1,0 +1,5 @@
+openssl genrsa -out es-root.key 2048
+openssl req -x509 -new -nodes -key es-root.key -days 10000 -out es-root.crt -subj '/C=US/ST=Oregon/L=Portland/CN=fishbaseapi.info'
+openssl genrsa -out es.key 2048
+openssl req -new -key es.key -out es.csr -subj '/C=US/ST=Oregon/L=Portland/CN=fishbaseapi.info'
+openssl x509 -req -in es.csr -CA es-root.crt -CAkey es-root.key -CAcreateserial -out es.crt -days 10000

--- a/create-keys.sh
+++ b/create-keys.sh
@@ -4,7 +4,10 @@ openssl genrsa -out es.key 2048
 openssl req -new -key es.key -out es.csr -subj '/C=US/ST=Oregon/L=Portland/CN=fishbaseapi.info'
 openssl x509 -req -in es.csr -CA es-root.crt -CAkey es-root.key -CAcreateserial -out es.crt -days 10000
 
+# sudo htpasswd -bc .htpasswd $USERNAME $PASSWORD
 
+## Not necessary/functional, just approve with a self-signed certificate (e.g. curl -k)
 #sudo mkdir /usr/local/share/ca-certificates/fishbaseapi
 #sudo cp es-root.crt /usr/local/share/ca-certificates/fishbaseapi/
 #sudo update-ca-certificates
+

--- a/create-keys.sh
+++ b/create-keys.sh
@@ -3,3 +3,8 @@ openssl req -x509 -new -nodes -key es-root.key -days 10000 -out es-root.crt -sub
 openssl genrsa -out es.key 2048
 openssl req -new -key es.key -out es.csr -subj '/C=US/ST=Oregon/L=Portland/CN=fishbaseapi.info'
 openssl x509 -req -in es.csr -CA es-root.crt -CAkey es-root.key -CAcreateserial -out es.crt -days 10000
+
+
+#sudo mkdir /usr/local/share/ca-certificates/fishbaseapi
+#sudo cp es-root.crt /usr/local/share/ca-certificates/fishbaseapi/
+#sudo update-ca-certificates

--- a/docker.sh
+++ b/docker.sh
@@ -19,7 +19,8 @@ docker run --name fbmysql \
 
 docker run --name fbgeoip -d allingeek/docker-freegeoip
 
-docker build -t  ropensci/fishbaseapi:latest .
+#docker build -t  ropensci/fishbaseapi:latest .
+docker pull ropensci/fishbaseapi:latest
 docker run --name fbapi -d \
   --link fbmysql:mysql \
   --link fbredis:redis \

--- a/docker.sh
+++ b/docker.sh
@@ -8,20 +8,35 @@ docker run --name fblogstash -d \
   -v /var/log/fishbase \
   -v ${PWD}/logstashconf:/opt/logstash/conf.d \
 	pblittle/docker-logstash
-## ##  -e LOGSTASH_CONFIG_URL=https://raw.githubusercontent.com/ropensci/fishbaseapi/master/logstash.conf \
 
-docker run --name fbmysql --restart=always -d -v $HOME/data/fishbase:/var/lib/mysql -e MYSQL_ROOT_PASSWORD=root mysql:latest
+##  -e LOGSTASH_CONFIG_URL=https://raw.githubusercontent.com/ropensci/fishbaseapi/master/logstash.conf \
+
+docker run --name fbmysql \
+  --restart=always -d \
+  -v $HOME/data/fishbase:/var/lib/mysql \
+  -e MYSQL_ROOT_PASSWORD=root \
+  mysql:latest
 
 docker run --name fbgeoip -d allingeek/docker-freegeoip
 
 docker build -t  ropensci/fishbaseapi:latest .
-docker run --name fbapi -d --link fbmysql:mysql --link fbredis:redis --link fbgeoip:geoip --volumes-from fblogstash ropensci/fishbaseapi:latest
+docker run --name fbapi -d \
+  --link fbmysql:mysql \
+  --link fbredis:redis \
+  --link fbgeoip:geoip \
+  --volumes-from fblogstash \
+  ropensci/fishbaseapi:latest
 
 # Must generate a .htpassword file first:
 # assuming apache2-utils is installed: sudo htpasswd -cb .htpasswd $USER $PASSWORD
 
-docker run --name fbnginx -d -p 80:80 --link fblogstash:logstash --link fbapi:api -v ${PWD}/nginx.conf:/etc/nginx/nginx.conf -v ${PWD}/.htpasswd:/etc/nginx/.htpasswd nginx:latest
-
-## don't expose logstash ports until they are secure
-# docker run --name fbnginx -d -p 80:80 -p 9200:9200 -p 9292:9292 --link fblogstash:logstash --link fbapi:api -v ${PWD}/nginx.conf:/etc/nginx/nginx.conf -v ${PWD}/.htpasswd:/etc/nginx/.htpasswd nginx:latest
+docker run --name fbnginx \
+  -d -p 80:80 -p 9200:9200 -p 9292:9292 \
+  --link fblogstash:logstash \
+  --link fbapi:api \
+  -v ${PWD}/nginx.conf:/etc/nginx/nginx.conf \
+  -v ${PWD}/.htpasswd:/etc/nginx/.htpasswd \
+  -v ${PWD}/es.crt:/etc/ssl/certs/es.crt \
+  -v ${PWD}/es.key:/etc/ssl/private/es.key \
+  nginx:latest
 

--- a/docker.sh
+++ b/docker.sh
@@ -7,7 +7,8 @@ docker run --name fbredis -d redis:latest
 docker run --name fblogstash -d \
   -v /var/log/fishbase \
   -v ${PWD}/logstashconf:/opt/logstash/conf.d \
-	pblittle/docker-logstash
+  -e ES_PROXY_HOST=$ESHOST \
+  pblittle/docker-logstash
 
 ##  -e LOGSTASH_CONFIG_URL=https://raw.githubusercontent.com/ropensci/fishbaseapi/master/logstash.conf \
 

--- a/docker.sh
+++ b/docker.sh
@@ -31,8 +31,8 @@ docker run --name fbapi -d \
 # Must generate a .htpassword file first:
 # assuming apache2-utils is installed: sudo htpasswd -cb .htpasswd $USER $PASSWORD
 
-docker run --name fbnginx \
-  -d -p 80:80 -p 9200:9200 -p 9292:9292 \
+docker run --name fbnginx -d \
+  -p 80:80 -p 9200:9200 -p 9292:9292 \
   --link fblogstash:logstash \
   --link fbapi:api \
   -v ${PWD}/nginx.conf:/etc/nginx/nginx.conf \

--- a/fig.yml
+++ b/fig.yml
@@ -1,6 +1,9 @@
 redis:
   image: redis:latest
 
+geoip:
+  image: allingeek/docker-freegeoip
+
 mysql:
   image: mysql:latest
   volumes: 
@@ -10,28 +13,32 @@ mysql:
 
 logstash:
   image: pblittle/docker-logstash:latest
-  ports:
-    - "9292:9292"
-    - "9200:9200"
-  environment:
-    LOGSTASH_CONFIG_URL: https://raw.githubusercontent.com/ropensci/fishbaseapi/master/logstash.conf
     volumes:
-      - /root
+      - /var/log/fishbase
+      - ${PWD}/logstashconf:/opt/logstash/conf.d 
+#  environment:
+#    LOGSTASH_CONFIG_URL: https://raw.githubusercontent.com/ropensci/fishbaseapi/master/logstash.conf
 
 api:
   image: ropensci/fishbaseapi:latest
   links:
     - mysql
     - redis
-  ports:
-   - "80:80"
+    - geoip
   volumes_from: 
     - logstash
 
 nginx:
   image: nginx:latest
-  net: "container:fishbaseapi_api_1"
+  ports:
+   - "80:80"
+   - "9292:9292"
+   - "9200:9200"
+  links:
+    - logstash
+    - api
   volumes:
     - ${PWD}/nginx.conf:/etc/nginx/nginx.conf
-  volumes_from: 
-    - api
+    - ${PWD}/.htpasswd:/etc/nginx/.htpasswd
+    - ${PWD}/es.crt:/etc/ssl/certs/es.crt
+    - ${PWD}/es.key:/etc/ssl/private/es.key

--- a/nginx.conf
+++ b/nginx.conf
@@ -38,6 +38,9 @@ http {
 
       listen 9292;
       server_name localhost;
+      ssl on;
+      ssl_certificate /etc/ssl/certs/es.crt;
+      ssl_certificate_key /etc/ssl/private/es.key;
 
       try_files $uri/index.html $uri @kibana;
 
@@ -47,8 +50,8 @@ http {
           proxy_redirect off;
           proxy_pass http://kibana;
 
-#          auth_basic "Restricted";                    #For Basic Auth
-#          auth_basic_user_file /etc/nginx/.htpasswd;  #For Basic Auth
+          auth_basic "Restricted";                    #For Basic Auth
+          auth_basic_user_file /etc/nginx/.htpasswd;  #For Basic Auth
 
       }
 
@@ -71,13 +74,16 @@ http {
 
      client_max_body_size 0; # disable any limits to avoid HTTP 413 for large image uploads
 
-     # required to avoid HTTP 411: see Issue #1486 (https://github.com/dotcloud/docker/issues/1486)
-     chunked_transfer_encoding on;
-
-
      try_files $uri/index.html $uri @elasticsearch;
 
      location @elasticsearch {
+       
+      ## Make elasticsearch read-only to avoid attacks
+       if ($request_method !~ "GET") {
+         return 403;
+         break;
+       }
+
          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
          proxy_set_header Host $http_host;
          proxy_redirect off;

--- a/nginx.conf
+++ b/nginx.conf
@@ -54,7 +54,7 @@ http {
 
 
       error_page 500 502 503 504 /500.html;
-      client_max_body_size 4G;
+      client_max_body_size 0;
       keepalive_timeout 0;
 
   }
@@ -90,7 +90,6 @@ http {
 
 
      error_page 500 502 503 504 /500.html;
-     client_max_body_size 4G;
      keepalive_timeout 0;
 
  }
@@ -111,7 +110,7 @@ http {
 
 
       error_page 500 502 503 504 /500.html;
-      client_max_body_size 4G;
+      client_max_body_size 0;
       keepalive_timeout 0;
 
   }

--- a/nginx.conf
+++ b/nginx.conf
@@ -60,30 +60,42 @@ http {
   }
   server {
 
-      listen 9200;
-      server_name localhost;
+     listen 9200;
+     server_name localhost;
+     ssl on;
+     ssl_certificate /etc/ssl/certs/es.crt;
+     ssl_certificate_key /etc/ssl/private/es.key;
 
-      try_files $uri/index.html $uri @elasticsearch;
+     proxy_set_header Host       $http_host;   # required for Docker client sake
+     proxy_set_header X-Real-IP  $remote_addr; # pass on real client IP
 
-      location @elasticsearch {
-          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-          proxy_set_header Host $http_host;
-          proxy_redirect off;
-          proxy_pass http://elasticsearch;
+     client_max_body_size 0; # disable any limits to avoid HTTP 413 for large image uploads
 
-          auth_basic "Restricted";                    #For Basic Auth
-          auth_basic_user_file /etc/nginx/.htpasswd;  #For Basic Auth
-
-      }
+     # required to avoid HTTP 411: see Issue #1486 (https://github.com/dotcloud/docker/issues/1486)
+     chunked_transfer_encoding on;
 
 
-      error_page 500 502 503 504 /500.html;
-      client_max_body_size 4G;
-      keepalive_timeout 0;
+     try_files $uri/index.html $uri @elasticsearch;
 
-  }
+     location @elasticsearch {
+         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+         proxy_set_header Host $http_host;
+         proxy_redirect off;
+         proxy_pass http://elasticsearch;
 
-  server {
+         auth_basic "Restricted";                    #For Basic Auth
+         auth_basic_user_file /etc/nginx/.htpasswd;  #For Basic Auth
+
+     }
+
+
+     error_page 500 502 503 504 /500.html;
+     client_max_body_size 4G;
+     keepalive_timeout 0;
+
+ }
+
+ server {
 
       listen 80;
       server_name localhost;


### PR DESCRIPTION
Puts the Elasticsearch port behind a password-protected HTTPS layer & makes it accept GET requests only (e.g. be read-only)

Adds instructions/script for generating self-signed certificate for the HTTPS step.  I've already created and deployed this on fishbaseapi.info.

Updates the htpassword file

I think this should close issue #49.  Kibana is also behind the https layer, but I haven't tried getting it to authenticate yet.
