### PR TITLE
fix tests

### DIFF
--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -22,29 +22,28 @@ describe API do
   end
 
   it 'lists endpoints' do
-    get '/heartbeat'
+    get '/heartbeat/'
     expect(last_response).to be_ok
     expect(JSON.parse(last_response.body)['routes'].length).to eq Models.models.length + 4
   end
 
-  it 'redirects root to heartbeat' do
+  it 'shows home page' do
     get '/'
-    expect(last_response).to be_redirect
-    expect(last_response.location).to eq 'http://example.org/heartbeat'
+    expect(last_response).to be_ok
   end
 
   context 'shows docs' do
-    subject { get '/docs'; last_response }
+    subject { get '/docs/'; last_response }
     it { is_expected.to be_ok }
   end
 
   context 'pings the db' do
-    subject { get '/mysqlping'; last_response }
+    subject { get '/mysqlping/'; last_response }
     it { is_expected.to be_ok }
   end
 
   context 'lists fields' do
-    subject { get '/listfields'; last_response }
+    subject { get '/listfields/'; last_response }
     it { is_expected.to be_ok }
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,8 @@ module TestHelperMixin
   end
 end
 
+ActiveRecord::Base.configurations.merge!('test' =>  { adapter: 'nulldb' })
+
 RSpec.configure do |config|
   config.include TestHelperMixin
 end


### PR DESCRIPTION
i fixed 3 issues.

1. `ActiveRecord::Base.configurations.merge!('test' =>  { adapter: 'nulldb' })` makes the tests stop whining about an unknown adapter
2. Not using trailing slashes was causing redirects, which threw off the tests 
3. Root is no longer a redirect to heartbeat, it is now a homepage with content
